### PR TITLE
Reverted phpdoc_separation config and locked CS Fixer version at 3.9.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.1.x-dev"
+            "dev-main": "1.2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "friendsofphp/php-cs-fixer": "v3.9.5",
+        "friendsofphp/php-cs-fixer": "3.9.5",
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "friendsofphp/php-cs-fixer": "v3.9.5",
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0"
     },
     "require-dev": {

--- a/src/lib/PhpCsFixer/Config.php
+++ b/src/lib/PhpCsFixer/Config.php
@@ -119,12 +119,7 @@ class Config extends ConfigBase
             'phpdoc_no_useless_inheritdoc' => true,
             'phpdoc_return_self_reference' => true,
             'phpdoc_scalar' => true,
-            'phpdoc_separation' => [
-                'groups' => [
-                    ['Assert\\*'],
-                    ['ORM\\*'],
-                ],
-            ],
+            'phpdoc_separation' => true,
             'phpdoc_single_line_var_spacing' => true,
             'phpdoc_summary' => true,
             'phpdoc_trim' => true,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | bug
| **Related PR**                                   | Partially reverts #2
| **Target package version** | 1.2.0
| **BC breaks**                          | no

This PR reverts `phpdoc_separation` config (see #2) to the one used by PHP Coding Standards Fixer `v3.9.5` and locks `friendsofphp/php-cs-fixer` at `v3.9.5`.

This is going to be tagged as v1.2.0 release. It will fix the issue when some packages are able to install Fixer `v3.14` (actually anything `> v3.9`) while some other packages, due to hard indirect dependency on `doctrine/annotations ^1`, are able to install 3.9.5 at most ATM.

So to get rid of this maintenance hell, we need to lock PHP CS Fixer at `v3.9.5` and stop trying to maintain all of our repositories when new version of PHP CS Fixer gets released. The idea here is that we include PHP CS Fixer upgrade as a part of pre-release check (the same way we handle UI translations) - we're gonna bump dependency then and go through all ezsystems and/or ibexa packages to update CS.

Long term plan is to follow more closely [PHP Coding Standards installation documentation](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.14.3#installation) and install this globally for all packages both for local dev setup and CI setup.

This change is going to negatively impact 3rd party developers directly using this package as they're going to be forced to use older version of PHP CS Fixer until the next Ibexa DXP release. However maintenance cost for Ibexa at this point is too high.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [ ] Asked for a review
