### PR TITLE
Updated php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "friendsofphp/php-cs-fixer": "3.9.5",
+        "friendsofphp/php-cs-fixer": "3.30.0",
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0"
     },
     "require-dev": {
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.2.x-dev"
+            "dev-main": "1.3.x-dev"
         }
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target package version** | ?
| **BC breaks**                          | yes (new rules will break CI)

Updated php-cs-fixer library to the latest version.

> Detected deprecations in use:
> - Rule "braces" is deprecated. Use "single_space_around_construct", "control_structure_braces", "control_structure_continuation_position", "declare_parentheses", "no_multiple_statements_per_line", "curly_braces_position", "statement_indentation" and "no_extra_blank_lines" instead.
> - Rule "function_typehint_space" is deprecated. Use "type_declaration_spaces" instead.
> - Rule "no_spaces_inside_parenthesis" is deprecated. Use "spaces_inside_parentheses" instead.
> - Rule "no_trailing_comma_in_list_call" is deprecated. Use "no_trailing_comma_in_singleline" instead.
> - Rule "no_trailing_comma_in_singleline_array" is deprecated. Use "no_trailing_comma_in_singleline" instead.
> - Rule "single_blank_line_before_namespace" is deprecated. Use "blank_lines_before_namespace" instead.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/php-dev`).
