### PR TITLE
[Code Style 2.0] Configured new rules for Ibexa Code Style 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ This package contains Ibexa Coding Standards which are aimed to include plugins
 for code style tools, plugins for CI, IDE settings, Git hooks, GitHub templates related  
 to contributions, etc.
 
+## Installation and backward compatibility promise
+
+This package doesn't follow strict SemVer BC promise due to maintenance reasons.
+Backward compatibility is guaranteed within a single minor release, instead of a major one.
+
+We recommend installing it using tilde (`~`) composer constraint followed by `X.Y.Z` version number format, e.g.: 
+```bash
+composer req --dev ibexa/code-style:~2.0.0
+```
+This ensures that composer will install `v2.0.*` patch releases only.
+Minor releases might receive configuration updates either needed by [Ibexa DXP](https://www.ibexa.co/products)
+packages or other changes forced by PHP CS Fixer package itself. 
+
 ## Usage
 
 ### Third party packages

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     },
     "require": {
         "php": ">=7.4",
-        "friendsofphp/php-cs-fixer": "3.30.0",
+        "friendsofphp/php-cs-fixer": "v3.53.0",
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.10.66"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.3.x-dev"
+            "dev-main": "2.0.x-dev"
         }
     }
 }

--- a/src/lib/PhpCsFixer/Config.php
+++ b/src/lib/PhpCsFixer/Config.php
@@ -185,6 +185,11 @@ class Config extends ConfigBase
             'self_accessor' => false,
             'static_lambda' => true,
             'ordered_imports' => true,
+            'class_definition' => [
+                'single_item_single_line' => true,
+                'inline_constructor_arguments' => false,
+            ],
+            'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
         ]);
     }
 }

--- a/src/lib/PhpCsFixer/Config.php
+++ b/src/lib/PhpCsFixer/Config.php
@@ -15,7 +15,7 @@ class Config extends ConfigBase
     /**
      * @param string $name
      */
-    public function __construct($name = 'default')
+    public function __construct(string $name = 'default')
     {
         parent::__construct($name);
 
@@ -33,7 +33,7 @@ class Config extends ConfigBase
             'lowercase_keywords' => true,
             'no_closing_tag' => true,
             'no_spaces_after_function_name' => true,
-            'no_spaces_inside_parenthesis' => true,
+            'spaces_inside_parentheses' => ['space' => 'none'],
             'no_trailing_whitespace' => true,
             'no_trailing_whitespace_in_comment' => true,
             'single_blank_line_at_eof' => true,
@@ -46,8 +46,8 @@ class Config extends ConfigBase
             'blank_line_before_statement' => [
                 'statements' => ['return'],
             ],
-            'braces' => [
-                'allow_single_line_closure' => true,
+            'braces_position' => [
+                'allow_single_line_anonymous_functions' => true,
             ],
             'class_attributes_separation' => [
                 'elements' => [
@@ -56,7 +56,7 @@ class Config extends ConfigBase
                 ],
             ],
             'declare_equal_normalize' => true,
-            'function_typehint_space' => true,
+            'type_declaration_spaces' => ['elements' => ['function', 'property']],
             'include' => true,
             'increment_style' => true,
             'lowercase_cast' => true,
@@ -65,8 +65,8 @@ class Config extends ConfigBase
             'magic_method_casing' => true,
             'method_argument_space' => true,
             'native_function_casing' => true,
-            'native_function_type_declaration_casing' => true,
-            'new_with_braces' => true,
+            'native_type_declaration_casing' => true,
+            'new_with_parentheses' => ['named_class' => true, 'anonymous_class' => true],
             'no_blank_lines_after_class_opening' => true,
             'no_blank_lines_after_phpdoc' => true,
             'no_empty_comment' => true,
@@ -87,10 +87,9 @@ class Config extends ConfigBase
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
             'no_spaces_around_offset' => true,
-            'no_trailing_comma_in_list_call' => true,
-            'no_trailing_comma_in_singleline_array' => true,
+            'no_trailing_comma_in_singleline' => ['elements' => ['arguments', 'array_destructuring', 'array', 'group_import']],
             'no_unneeded_control_parentheses' => true,
-            'no_unneeded_curly_braces' => true,
+            'no_unneeded_braces' => true,
             'no_unneeded_final_method' => true,
             'no_unused_imports' => true,
             'no_whitespace_before_comma_in_array' => true,
@@ -173,7 +172,7 @@ class Config extends ConfigBase
             'phpdoc_to_comment' => false,
             'cast_spaces' => false,
             'blank_line_after_opening_tag' => false,
-            'single_blank_line_before_namespace' => true,
+            'blank_lines_before_namespace' => true,
             'space_after_semicolon' => false,
             'native_function_invocation' => false,
             'phpdoc_types_order' => [

--- a/src/lib/PhpCsFixer/InternalConfigFactory.php
+++ b/src/lib/PhpCsFixer/InternalConfigFactory.php
@@ -24,7 +24,7 @@ final class InternalConfigFactory
 EOF;
 
     /** @var array<string, mixed> */
-    private $customRules = [];
+    private array $customRules = [];
 
     /**
      * @param array<string, mixed> $rules
@@ -46,7 +46,7 @@ EOF;
         $specificRules = [
             'header_comment' => [
                 'comment_type' => 'PHPDoc',
-                'header' => static::IBEXA_PHP_HEADER,
+                'header' => self::IBEXA_PHP_HEADER,
                 'location' => 'after_open',
                 'separate' => 'top',
             ],
@@ -63,8 +63,6 @@ EOF;
 
     public static function build(): ConfigInterface
     {
-        $self = new self();
-
-        return $self->buildConfig();
+        return (new self())->buildConfig();
     }
 }

--- a/src/lib/PhpCsFixer/InternalConfigFactory.php
+++ b/src/lib/PhpCsFixer/InternalConfigFactory.php
@@ -18,9 +18,6 @@ use PhpCsFixer\ConfigInterface;
  */
 final class InternalConfigFactory
 {
-    /** @deprecated Use IBEXA_PHP_HEADER constant instead. */
-    public const EZPLATFORM_PHP_HEADER = self::IBEXA_PHP_HEADER;
-
     public const IBEXA_PHP_HEADER = <<<'EOF'
 @copyright Copyright (C) Ibexa AS. All rights reserved.
 @license For full copyright and license information view LICENSE file distributed with this source code.


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | feature
| **Target package version** |  new major 2.0
| **BC breaks**                          | yes

We've observed that we need some new PHP CS Fixer rules (`class_definition`, `php_unit_test_case_static_method_calls`) and also a better way to maintain adding them.

This PR:
- [x] bumps package version to major 2.0
- [x] bumps PHP CS Fixer to the latest released version (still enforcing concrete version requirement)
- [x] updates deprecated PHP CS Fixer configuration [1]
- [x] adds new configuration rules
- [x] adds a doc about how to install the package to avoid BC breaks
- [x] bumps PHPStan to the latest version (`require-dev` only)
- [x] drops deprecation
- [x] fixes minor CS issues


[1] Deprecated configuration fixed:
```
Detected deprecations in use:
- Rule "braces" is deprecated. Use "single_space_around_construct", "control_structure_braces", "control_structure_continuation_position", "declare_parentheses", "no_multiple_statements_per_line", "curly_braces_position", "statement_indentation" and "no_extra_blank_lines" instead.
- Rule "function_typehint_space" is deprecated. Use "type_declaration_spaces" instead.
- Rule "native_function_type_declaration_casing" is deprecated. Use "native_type_declaration_casing" instead.
- Rule "new_with_braces" is deprecated. Use "new_with_parentheses" instead.
- Rule "no_spaces_inside_parenthesis" is deprecated. Use "spaces_inside_parentheses" instead.
- Rule "no_trailing_comma_in_list_call" is deprecated. Use "no_trailing_comma_in_singleline" instead.
- Rule "no_trailing_comma_in_singleline_array" is deprecated. Use "no_trailing_comma_in_singleline" instead.
- Rule "no_unneeded_curly_braces" is deprecated. Use "no_unneeded_braces" instead.
- Rule "single_blank_line_before_namespace" is deprecated. Use "blank_lines_before_namespace" instead.
```

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.
