### PR TITLE
Reconfigured `phpdoc_no_alias_tag` rule to not replace the `@link` tag

### DIFF
--- a/src/lib/PhpCsFixer/Config.php
+++ b/src/lib/PhpCsFixer/Config.php
@@ -111,7 +111,6 @@ class Config extends ConfigBase
             'phpdoc_no_alias_tag' => [
                 'replacements' => [
                     'type' => 'var',
-                    'link' => 'see',
                 ],
             ],
             'phpdoc_no_empty_return' => true,


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|
| Target version | **1.2** |

#### Description:

This PR changes a configuration of the `phpdoc_no_alias_tag` rule so `@link` occurrences of are not replaced with `@see`

As @adriendupuis explained:
> This rule pretends that `@link` should be replaced by `@see`.
But those two tags are not equivalent. Syntaxes, meanings and rendering are
`@see what\to\see why you should see` is more for references and works like `<a href="what_to_see.html">what\to\see</a><br/>why you should see` 
> `@link https://what_to_see/ <link text>`; `@link` is more for URL and work like a `<a href="https://what_to_see/">link text</a>`

#### BC consideration

This change is BC safe as it prevents from changing new code occurrences, while it's not going to touch existing ones.
Targeting for 1.2 as ibexa/core:4.6 currently needs to use that older version due to PHPUnit constraints conflict.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
