### PR TITLE
Introduced `types_spaces` code style rule

### DIFF
--- a/src/lib/PhpCsFixer/Sets/Ibexa50RuleSet.php
+++ b/src/lib/PhpCsFixer/Sets/Ibexa50RuleSet.php
@@ -49,6 +49,9 @@ final class Ibexa50RuleSet extends AbstractIbexaRuleSet
                 'php_unit_test_case_static_method_calls' => [
                     'call_type' => 'self',
                 ],
+                'types_spaces' => [
+                    'space' => 'single',
+                ],
             ],
         );
     }

--- a/tests/lib/Sets/expected_rules/5_0_rule_set/local_rules.php
+++ b/tests/lib/Sets/expected_rules/5_0_rule_set/local_rules.php
@@ -211,6 +211,9 @@ return [
             'property',
         ],
     ],
+    'types_spaces' => [
+        'space' => 'single',
+    ],
     'unary_operator_spaces' => true,
     'visibility_required' => true,
     'whitespace_after_comma_in_array' => true,

--- a/tests/lib/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
+++ b/tests/lib/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
@@ -201,4 +201,7 @@ return [
     'php_unit_test_case_static_method_calls' => [
         'call_type' => 'self',
     ],
+    'types_spaces' => [
+        'space' => 'single',
+    ],
 ];


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR introduces [`types_spaces` rule](https://cs.symfony.com/doc/rules/whitespace/types_spaces.html).

We can operate on 4 sets:
 * we do set `space` as required for class intersection/union
 * we do set `none`, so no spaces
 * we differentiate between exception throwing blocks and everything else
 * we do not set anything, and let remain it on case-by-case basis.

Currently suggested:
```diff
--- Original
+++ New
 <?php
 try
 {
     new Foo();
-} catch (ErrorA|ErrorB $e) {
+} catch (ErrorA | ErrorB $e) {
 echo'error';}
```

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
