### PR TITLE
Added rule for splitting multiple methods arguments into multiline if there is more than one

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,4 @@ parameters:
     checkMissingCallableSignature: true
     paths:
         - src
+        - tests

--- a/src/lib/PhpCsFixer/Rule/MultilineParametersFixer.php
+++ b/src/lib/PhpCsFixer/Rule/MultilineParametersFixer.php
@@ -43,15 +43,15 @@ final class MultilineParametersFixer extends AbstractFixer
                 continue;
             }
 
-            $openParenIndex = $tokens->getNextTokenOfKind($index, ['(']);
-            if ($openParenIndex === null) {
+            $openParentIndex = $tokens->getNextTokenOfKind($index, ['(']);
+            if ($openParentIndex === null) {
                 continue;
             }
 
-            $closeParenIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenIndex);
+            $closeParenIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParentIndex);
 
             // Count commas to determine parameter count
-            $paramCount = $this->countParameters($tokens, $openParenIndex, $closeParenIndex);
+            $paramCount = $this->countParameters($tokens, $openParentIndex, $closeParenIndex);
 
             // Only process if 2+ parameters
             if ($paramCount < 2) {
@@ -59,12 +59,12 @@ final class MultilineParametersFixer extends AbstractFixer
             }
 
             // Check if already multiline
-            if ($this->isMultiline($tokens, $openParenIndex, $closeParenIndex)) {
+            if ($this->isMultiline($tokens, $openParentIndex, $closeParenIndex)) {
                 continue;
             }
 
             // Apply multiline formatting
-            $this->makeMultiline($tokens, $openParenIndex, $closeParenIndex);
+            $this->makeMultiline($tokens, $openParentIndex, $closeParenIndex);
         }
     }
 
@@ -118,19 +118,19 @@ final class MultilineParametersFixer extends AbstractFixer
 
     private function makeMultiline(
         Tokens $tokens,
-        int $openParenIndex,
+        int $openParentIndex,
         int $closeParenIndex
     ): void {
-        $indent = $this->detectIndent($tokens, $openParenIndex);
+        $indent = $this->detectIndent($tokens, $openParentIndex);
         $lineIndent = str_repeat(' ', 4); // 4 spaces for parameters
 
         // Add newline after opening parenthesis
-        $tokens->insertAt($openParenIndex + 1, new Token([T_WHITESPACE, "\n" . $indent . $lineIndent]));
+        $tokens->insertAt($openParentIndex + 1, new Token([T_WHITESPACE, "\n" . $indent . $lineIndent]));
         ++$closeParenIndex;
 
         // Find all commas and add newlines after them
         $depth = 0;
-        for ($i = $openParenIndex + 1; $i < $closeParenIndex; ++$i) {
+        for ($i = $openParentIndex + 1; $i < $closeParenIndex; ++$i) {
             if ($tokens[$i]->equals('(') || $tokens[$i]->equals('[')) {
                 ++$depth;
             } elseif ($tokens[$i]->equals(')') || $tokens[$i]->equals(']')) {
@@ -145,7 +145,7 @@ final class MultilineParametersFixer extends AbstractFixer
 
                 // Insert newline with proper indentation
                 $tokens->insertAt($i + 1, new Token([T_WHITESPACE, "\n" . $indent . $lineIndent]));
-                $closeParenIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenIndex);
+                $closeParenIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParentIndex);
             }
         }
 

--- a/src/lib/PhpCsFixer/Rule/MultilineParametersFixer.php
+++ b/src/lib/PhpCsFixer/Rule/MultilineParametersFixer.php
@@ -44,6 +44,10 @@ final class MultilineParametersFixer extends AbstractFixer
             }
 
             $openParenIndex = $tokens->getNextTokenOfKind($index, ['(']);
+            if ($openParenIndex === null) {
+                continue;
+            }
+
             $closeParenIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenIndex);
 
             // Count commas to determine parameter count
@@ -150,7 +154,7 @@ final class MultilineParametersFixer extends AbstractFixer
 
         // Handle the opening brace
         $nextNonWhitespace = $tokens->getNextNonWhitespace($closeParenIndex);
-        if ($nextNonWhitespace !== null && $tokens[$nextNonWhitespace]->equals(T_CURLY_OPEN)) {
+        if ($nextNonWhitespace !== null && $tokens[$nextNonWhitespace]->equals('{')) {
             $tokens->ensureWhitespaceAtIndex($nextNonWhitespace - 1, 1, ' ');
         }
     }

--- a/src/lib/PhpCsFixer/Rule/MultilineParametersFixer.php
+++ b/src/lib/PhpCsFixer/Rule/MultilineParametersFixer.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\CodeStyle\PhpCsFixer\Rule;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class MultilineParametersFixer extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Methods and functions with 2+ parameters must use multiline format',
+            [
+                new CodeSample(
+                    '<?php function foo(string $a, int $b): void {}'
+                ),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_FUNCTION);
+    }
+
+    protected function applyFix(
+        \SplFileInfo $file,
+        Tokens $tokens
+    ): void {
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_FUNCTION)) {
+                continue;
+            }
+
+            $openParenIndex = $tokens->getNextTokenOfKind($index, ['(']);
+            $closeParenIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenIndex);
+
+            // Count commas to determine parameter count
+            $paramCount = $this->countParameters($tokens, $openParenIndex, $closeParenIndex);
+
+            // Only process if 2+ parameters
+            if ($paramCount < 2) {
+                continue;
+            }
+
+            // Check if already multiline
+            if ($this->isMultiline($tokens, $openParenIndex, $closeParenIndex)) {
+                continue;
+            }
+
+            // Apply multiline formatting
+            $this->makeMultiline($tokens, $openParenIndex, $closeParenIndex);
+        }
+    }
+
+    private function countParameters(
+        Tokens $tokens,
+        int $start,
+        int $end
+    ): int {
+        $count = 0;
+        $depth = 0;
+
+        for ($i = $start + 1; $i < $end; ++$i) {
+            if ($tokens[$i]->equals('(') || $tokens[$i]->equals('[')) {
+                ++$depth;
+            } elseif ($tokens[$i]->equals(')') || $tokens[$i]->equals(']')) {
+                --$depth;
+            } elseif ($depth === 0 && $tokens[$i]->equals(',')) {
+                ++$count;
+            }
+        }
+
+        // If we found any commas, param count is commas + 1
+        // If no commas but there's content, it's 1 param
+        if ($count > 0) {
+            return $count + 1;
+        }
+
+        // Check if there's any non-whitespace content
+        for ($i = $start + 1; $i < $end; ++$i) {
+            if (!$tokens[$i]->isWhitespace()) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    private function isMultiline(
+        Tokens $tokens,
+        int $start,
+        int $end
+    ): bool {
+        for ($i = $start; $i <= $end; ++$i) {
+            if ($tokens[$i]->isGivenKind(T_WHITESPACE) && str_contains($tokens[$i]->getContent(), "\n")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function makeMultiline(
+        Tokens $tokens,
+        int $openParenIndex,
+        int $closeParenIndex
+    ): void {
+        $indent = $this->detectIndent($tokens, $openParenIndex);
+        $lineIndent = str_repeat(' ', 4); // 4 spaces for parameters
+
+        // Add newline after opening parenthesis
+        $tokens->insertAt($openParenIndex + 1, new Token([T_WHITESPACE, "\n" . $indent . $lineIndent]));
+        ++$closeParenIndex;
+
+        // Find all commas and add newlines after them
+        $depth = 0;
+        for ($i = $openParenIndex + 1; $i < $closeParenIndex; ++$i) {
+            if ($tokens[$i]->equals('(') || $tokens[$i]->equals('[')) {
+                ++$depth;
+            } elseif ($tokens[$i]->equals(')') || $tokens[$i]->equals(']')) {
+                --$depth;
+            } elseif ($depth === 0 && $tokens[$i]->equals(',')) {
+                // Remove any whitespace after comma
+                $nextIndex = $i + 1;
+                while ($nextIndex < $closeParenIndex && $tokens[$nextIndex]->isWhitespace()) {
+                    $tokens->clearAt($nextIndex);
+                    ++$nextIndex;
+                }
+
+                // Insert newline with proper indentation
+                $tokens->insertAt($i + 1, new Token([T_WHITESPACE, "\n" . $indent . $lineIndent]));
+                $closeParenIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenIndex);
+            }
+        }
+
+        // Add newline before closing parenthesis
+        $tokens->insertAt($closeParenIndex, new Token([T_WHITESPACE, "\n" . $indent]));
+
+        // Handle the opening brace
+        $nextNonWhitespace = $tokens->getNextNonWhitespace($closeParenIndex);
+        if ($nextNonWhitespace !== null && $tokens[$nextNonWhitespace]->equals(T_CURLY_OPEN)) {
+            $tokens->ensureWhitespaceAtIndex($nextNonWhitespace - 1, 1, ' ');
+        }
+    }
+
+    private function detectIndent(
+        Tokens $tokens,
+        int $index
+    ): string {
+        // Look backwards to find the indentation of the current line
+        for ($i = $index - 1; $i >= 0; --$i) {
+            if ($tokens[$i]->isGivenKind(T_WHITESPACE) && str_contains($tokens[$i]->getContent(), "\n")) {
+                $lines = explode("\n", $tokens[$i]->getContent());
+
+                return end($lines);
+            }
+        }
+
+        return '';
+    }
+
+    public function getName(): string
+    {
+        return 'Ibexa/multiline_parameters';
+    }
+}

--- a/src/lib/PhpCsFixer/Rule/MultilineParametersFixer.php
+++ b/src/lib/PhpCsFixer/Rule/MultilineParametersFixer.php
@@ -48,10 +48,10 @@ final class MultilineParametersFixer extends AbstractFixer
                 continue;
             }
 
-            $closeParenIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParentIndex);
+            $closeParentIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParentIndex);
 
             // Count commas to determine parameter count
-            $paramCount = $this->countParameters($tokens, $openParentIndex, $closeParenIndex);
+            $paramCount = $this->countParameters($tokens, $openParentIndex, $closeParentIndex);
 
             // Only process if 2+ parameters
             if ($paramCount < 2) {
@@ -59,12 +59,12 @@ final class MultilineParametersFixer extends AbstractFixer
             }
 
             // Check if already multiline
-            if ($this->isMultiline($tokens, $openParentIndex, $closeParenIndex)) {
+            if ($this->isMultiline($tokens, $openParentIndex, $closeParentIndex)) {
                 continue;
             }
 
             // Apply multiline formatting
-            $this->makeMultiline($tokens, $openParentIndex, $closeParenIndex);
+            $this->makeMultiline($tokens, $openParentIndex, $closeParentIndex);
         }
     }
 
@@ -119,18 +119,18 @@ final class MultilineParametersFixer extends AbstractFixer
     private function makeMultiline(
         Tokens $tokens,
         int $openParentIndex,
-        int $closeParenIndex
+        int $closeParentIndex
     ): void {
         $indent = $this->detectIndent($tokens, $openParentIndex);
         $lineIndent = str_repeat(' ', 4); // 4 spaces for parameters
 
         // Add newline after opening parenthesis
         $tokens->insertAt($openParentIndex + 1, new Token([T_WHITESPACE, "\n" . $indent . $lineIndent]));
-        ++$closeParenIndex;
+        ++$closeParentIndex;
 
         // Find all commas and add newlines after them
         $depth = 0;
-        for ($i = $openParentIndex + 1; $i < $closeParenIndex; ++$i) {
+        for ($i = $openParentIndex + 1; $i < $closeParentIndex; ++$i) {
             if ($tokens[$i]->equals('(') || $tokens[$i]->equals('[')) {
                 ++$depth;
             } elseif ($tokens[$i]->equals(')') || $tokens[$i]->equals(']')) {
@@ -138,22 +138,22 @@ final class MultilineParametersFixer extends AbstractFixer
             } elseif ($depth === 0 && $tokens[$i]->equals(',')) {
                 // Remove any whitespace after comma
                 $nextIndex = $i + 1;
-                while ($nextIndex < $closeParenIndex && $tokens[$nextIndex]->isWhitespace()) {
+                while ($nextIndex < $closeParentIndex && $tokens[$nextIndex]->isWhitespace()) {
                     $tokens->clearAt($nextIndex);
                     ++$nextIndex;
                 }
 
                 // Insert newline with proper indentation
                 $tokens->insertAt($i + 1, new Token([T_WHITESPACE, "\n" . $indent . $lineIndent]));
-                $closeParenIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParentIndex);
+                $closeParentIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParentIndex);
             }
         }
 
         // Add newline before closing parenthesis
-        $tokens->insertAt($closeParenIndex, new Token([T_WHITESPACE, "\n" . $indent]));
+        $tokens->insertAt($closeParentIndex, new Token([T_WHITESPACE, "\n" . $indent]));
 
         // Handle the opening brace
-        $nextNonWhitespace = $tokens->getNextNonWhitespace($closeParenIndex);
+        $nextNonWhitespace = $tokens->getNextNonWhitespace($closeParentIndex);
         if ($nextNonWhitespace !== null && $tokens[$nextNonWhitespace]->equals('{')) {
             $tokens->ensureWhitespaceAtIndex($nextNonWhitespace - 1, 1, ' ');
         }

--- a/src/lib/PhpCsFixer/Sets/AbstractIbexaRuleSet.php
+++ b/src/lib/PhpCsFixer/Sets/AbstractIbexaRuleSet.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\CodeStyle\PhpCsFixer\Sets;
 
 use AdamWojs\PhpCsFixerPhpdocForceFQCN\Fixer\Phpdoc\ForceFQCNFixer;
+use Ibexa\CodeStyle\PhpCsFixer\Rule\MultilineParametersFixer;
 use PhpCsFixer\Config;
 
 abstract class AbstractIbexaRuleSet implements RuleSetInterface
@@ -26,6 +27,7 @@ abstract class AbstractIbexaRuleSet implements RuleSetInterface
         return [
             '@PSR12' => false,
             'AdamWojs/phpdoc_force_fqcn_fixer' => true,
+            'Ibexa/multiline_parameters' => true,
             'array_syntax' => [
                 'syntax' => 'short',
             ],
@@ -204,7 +206,7 @@ abstract class AbstractIbexaRuleSet implements RuleSetInterface
     public function buildConfig(): Config
     {
         $config = new Config();
-        $config->registerCustomFixers([new ForceFQCNFixer()]);
+        $config->registerCustomFixers([new ForceFQCNFixer(), new MultilineParametersFixer()]);
 
         $config->setRules(array_merge(
             $config->getRules(),

--- a/tests/lib/PhpCsFixer/InternalConfigFactoryTest.php
+++ b/tests/lib/PhpCsFixer/InternalConfigFactoryTest.php
@@ -38,8 +38,10 @@ final class InternalConfigFactoryTest extends TestCase
     /**
      * @dataProvider provideRuleSetTestCases
      */
-    public function testVersionBasedRuleSetSelection(array $package, string $expectedRuleSetClass): void
-    {
+    public function testVersionBasedRuleSetSelection(
+        array $package,
+        string $expectedRuleSetClass
+    ): void {
         $ruleSet = $this->createRuleSetFromPackage->invoke($this->factory, $package);
 
         self::assertInstanceOf($expectedRuleSetClass, $ruleSet);

--- a/tests/lib/PhpCsFixer/InternalConfigFactoryTest.php
+++ b/tests/lib/PhpCsFixer/InternalConfigFactoryTest.php
@@ -37,6 +37,9 @@ final class InternalConfigFactoryTest extends TestCase
 
     /**
      * @dataProvider provideRuleSetTestCases
+     *
+     * @param array{name: string, version: string, pretty_version?: string} $package
+     * @param class-string $expectedRuleSetClass
      */
     public function testVersionBasedRuleSetSelection(
         array $package,
@@ -47,6 +50,9 @@ final class InternalConfigFactoryTest extends TestCase
         self::assertInstanceOf($expectedRuleSetClass, $ruleSet);
     }
 
+    /**
+     * @return array<string, array{0: array{name: string, version: string, pretty_version?: string}, 1: class-string}>
+     */
     public function provideRuleSetTestCases(): array
     {
         return [

--- a/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
@@ -81,14 +81,14 @@ function test(
         yield 'constructor with properties should be split' => [
             '<?php
 class Test {
-    public function __construct(private string $foo, private int $bar) {
+    public function __construct(string $foo, int $bar) {
     }
 }',
             '<?php
 class Test {
     public function __construct(
-        private string $foo,
-        private int $bar
+        string $foo,
+        int $bar
     ) {
     }
 }',

--- a/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\CodeStyle\PhpCsFixer\Rule;
+
+use Ibexa\CodeStyle\PhpCsFixer\Rule\MultilineParametersFixer;
+use PhpCsFixer\Tokenizer\Tokens;
+use PHPUnit\Framework\TestCase;
+
+final class MultilineParametersFixerTest extends TestCase
+{
+    private MultilineParametersFixer $fixer;
+
+    protected function setUp(): void
+    {
+        $this->fixer = new MultilineParametersFixer();
+    }
+
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(
+        string $input,
+        string $expected
+    ): void {
+        $tokens = Tokens::fromCode($input);
+        $this->fixer->fix(new \SplFileInfo(__FILE__), $tokens);
+
+        self::assertSame($expected, $tokens->generateCode());
+    }
+
+    public static function provideFixCases(): iterable
+    {
+        yield 'single parameter should not be modified' => [
+            '<?php
+function bar(array $package): void {
+}',
+            '<?php
+function bar(array $package): void {
+}',
+        ];
+
+        yield 'single parameter with type hints should not be modified' => [
+            '<?php
+function bar(?string $package = null): void {
+}',
+            '<?php
+function bar(?string $package = null): void {
+}',
+        ];
+
+        yield 'multiple parameters should be split' => [
+            '<?php
+function foo(array $package, string $expectedRuleSetClass): void {
+}',
+            '<?php
+function foo(
+    array $package,
+    string $expectedRuleSetClass
+): void {
+}',
+        ];
+
+        yield 'multiple parameters with type hints should be split' => [
+            '<?php
+function test(?string $foo = null, int $bar = 42): string {
+}',
+            '<?php
+function test(
+    ?string $foo = null,
+    int $bar = 42
+): string {
+}',
+        ];
+
+        yield 'constructor with properties should be split' => [
+            '<?php
+class Test {
+    public function __construct(private string $foo, private int $bar) {
+    }
+}',
+            '<?php
+class Test {
+    public function __construct(
+        private string $foo,
+        private int $bar
+    ) {
+    }
+}',
+        ];
+
+        yield 'already multiline should not be modified' => [
+            '<?php
+function test(
+    string $foo,
+    int $bar
+): void {
+}',
+            '<?php
+function test(
+    string $foo,
+    int $bar
+): void {
+}',
+        ];
+    }
+}

--- a/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
@@ -34,6 +34,9 @@ final class MultilineParametersFixerTest extends TestCase
         self::assertSame($expected, $tokens->generateCode());
     }
 
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
     public static function provideFixCases(): iterable
     {
         yield 'single parameter should not be modified' => [

--- a/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
@@ -11,6 +11,7 @@ namespace Ibexa\Tests\CodeStyle\PhpCsFixer\Rule;
 use Ibexa\CodeStyle\PhpCsFixer\Rule\MultilineParametersFixer;
 use PhpCsFixer\Tokenizer\Tokens;
 use PHPUnit\Framework\TestCase;
+use SplFileInfo;
 
 final class MultilineParametersFixerTest extends TestCase
 {
@@ -29,7 +30,7 @@ final class MultilineParametersFixerTest extends TestCase
         string $expected
     ): void {
         $tokens = Tokens::fromCode($input);
-        $this->fixer->fix(new \SplFileInfo(__FILE__), $tokens);
+        $this->fixer->fix(new SplFileInfo(__FILE__), $tokens);
 
         self::assertSame($expected, $tokens->generateCode());
     }

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/local_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/local_rules.php
@@ -195,4 +195,5 @@ return [
     'visibility_required' => true,
     'whitespace_after_comma_in_array' => true,
     'yoda_style' => false,
+    'Ibexa/multiline_parameters' => true,
 ];

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/php_cs_fixer_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/php_cs_fixer_rules.php
@@ -179,4 +179,5 @@ return [
     'no_trailing_comma_in_singleline_array' => true,
     'no_unneeded_curly_braces' => true,
     'single_blank_line_before_namespace' => true,
+    'Ibexa/multiline_parameters' => true,
 ];

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/local_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/local_rules.php
@@ -218,4 +218,5 @@ return [
     'visibility_required' => true,
     'whitespace_after_comma_in_array' => true,
     'yoda_style' => false,
+    'Ibexa/multiline_parameters' => true,
 ];

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
@@ -204,4 +204,5 @@ return [
     'types_spaces' => [
         'space' => 'single',
     ],
+    'Ibexa/multiline_parameters' => true,
 ];


### PR DESCRIPTION
… 

| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
