### PR TITLE
Added syntax sugar to configure parallel run

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -14,7 +14,7 @@ $finder = PhpCsFixer\Finder::create()
     ->files()->name('*.php');
 
 $configFactory = new InternalConfigFactory();
-$configFactory->withRuleSet(new Sets\Ibexa50RuleSet());
+$configFactory->runInParallel()->withRuleSet(new Sets\Ibexa50RuleSet());
 
 $config = $configFactory->buildConfig();
 $config->setFinder($finder);

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ $config->setFinder(
 return $config;
 ```
 
+> [!TIP]
+> You can configure a parallel run of PHP CS Fixer by either calling:
+> ```php
+> $factory->runInParallel();
+> ```
+> or
+> ```php
+> InternalConfigFactory::build(runInParallel: true)
+> ```
+
 ### Ibexa packages
 
 Create a `.php-cs-fixer.php` file in your project root directory with the following content:


### PR DESCRIPTION
> [!CAUTION]
> - [x] Merge https://github.com/ibexa/code-style/pull/18 first

| :ticket: Issue | n/a |
|----------------|-----------|

#### Related PRs: 
- #18

#### Description:

As it seems, while parallel run has been available since Ibexa Code Style v2.1.0 (via PHP CS Fixer v3.75+), it was somewhat difficult to configure it, because it's exposed on another interface:
```php
use Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory;
use PhpCsFixer\ParallelAwareConfigInterface;
use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;

$factory = new InternalConfigFactory();
$factory->withRules([
    'declare_strict_types' => false,
]);

$config = $factory->buildConfig()
    ->setFinder(
        PhpCsFixer\Finder::create()
            ->in([
                __DIR__ . '/src',
                __DIR__ . '/tests',
            ])
            ->files()->name('*.php')
    );

if ($config instanceof ParallelAwareConfigInterface){
    $config->setParallelConfig(ParallelConfigFactory::detect());
}

return $config;
```

This PR adds syntax sugar for the `InternalConfigFactory`:
```php
use Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory;

$factory = new InternalConfigFactory();
$factory->withRules([
    'declare_strict_types' => false,
]);

return $factory->runInParallel()->buildConfig()
    ->setFinder(
        PhpCsFixer\Finder::create()
            ->in([
                __DIR__ . '/src',
                __DIR__ . '/tests',
            ])
            ->files()->name('*.php')
    );
```

or alternatively, following [bundle-generator-shipped config](https://github.com/ibexa/bundle-generator/blob/fdae9bf/skeleton/ibexa-ee/.php-cs-fixer.php#L9):
```php
return \Ibexa\CodeStyle\PhpCsFixer\InternalConfigFactory::build(runInParallel: true)->setFinder(
    PhpCsFixer\Finder::create()
        ->in(__DIR__ . '/src')
        ->in(__DIR__ . '/tests')
        ->files()->name('*.php')
);
```
I don't see a more friendly way of configuring it in case of the static `build` factory method, so recommending here using named parameters. Other suggestions welcomed.