### PR TITLE
Added `native_function_invocation` for `@compiler_optimized` functions

### DIFF
--- a/src/lib/PhpCsFixer/Sets/Ibexa50RuleSet.php
+++ b/src/lib/PhpCsFixer/Sets/Ibexa50RuleSet.php
@@ -28,6 +28,7 @@ final class Ibexa50RuleSet extends AbstractIbexaRuleSet
                         'property',
                     ],
                 ],
+                'native_function_invocation' => true,
                 'native_type_declaration_casing' => true,
                 'new_with_parentheses' => true,
                 'no_trailing_comma_in_singleline' => [

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/local_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/local_rules.php
@@ -84,7 +84,7 @@ return [
         'scope' => 'namespaced',
     ],
     'native_function_casing' => true,
-    'native_function_invocation' => false,
+    'native_function_invocation' => true,
     'native_type_declaration_casing' => true,
     'new_with_parentheses' => true,
     'no_alias_functions' => true,

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
@@ -100,6 +100,7 @@ return [
         'scope' => 'namespaced',
     ],
     'native_function_casing' => true,
+    'native_function_invocation' => true,
     'no_alias_functions' => true,
     'no_blank_lines_after_phpdoc' => true,
     'no_empty_comment' => true,


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR introduces a **risky rule** that will prefix all global, compiler optimized (generating simplified OPCode operations under certain conditions) function calls with `\`
https://cs.symfony.com/doc/rules/function_notation/native_function_invocation.html

<img width="957" height="544" alt="image" src="https://github.com/user-attachments/assets/2968a383-81ba-41c7-8acf-90516d54ab45" />

For example, it prefixes all `sprintf` calls, because in newer versions of PHP compiler can recognize that no special processing is actually being done (for example, `"Something %s" foo` is used as string) and can be replaced with interpolation OPCode instead).

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
