### PR TITLE
Ordered imports no groups

### DIFF
--- a/src/lib/PhpCsFixer/Sets/AbstractIbexaRuleSet.php
+++ b/src/lib/PhpCsFixer/Sets/AbstractIbexaRuleSet.php
@@ -130,7 +130,10 @@ abstract class AbstractIbexaRuleSet implements RuleSetInterface
             'non_printable_character' => true,
             'normalize_index_brace' => true,
             'object_operator_without_whitespace' => true,
-            'ordered_imports' => true,
+            'ordered_imports' => [
+                'imports_order' => null,
+                'sort_algorithm' => 'alpha',
+            ],
             'php_unit_construct' => true,
             'php_unit_fqcn_annotation' => true,
             'php_unit_mock_short_will_return' => false,

--- a/src/lib/PhpCsFixer/Sets/AbstractIbexaRuleSet.php
+++ b/src/lib/PhpCsFixer/Sets/AbstractIbexaRuleSet.php
@@ -131,7 +131,7 @@ abstract class AbstractIbexaRuleSet implements RuleSetInterface
             'normalize_index_brace' => true,
             'object_operator_without_whitespace' => true,
             'ordered_imports' => [
-                'imports_order' => null,
+                'imports_order' => ['class', 'function', 'const'],
                 'sort_algorithm' => 'alpha',
             ],
             'php_unit_construct' => true,

--- a/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\CodeStyle\PhpCsFixer\Rule;
+
+use Ibexa\CodeStyle\PhpCsFixer\Sets\Ibexa50RuleSet;
+use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
+use PhpCsFixer\Tokenizer\Tokens;
+use PHPUnit\Framework\TestCase;
+use SplFileInfo;
+
+final class OrderedImportsFixerTest extends TestCase
+{
+    private OrderedImportsFixer $fixer;
+
+    protected function setUp(): void
+    {
+        $this->fixer = new OrderedImportsFixer();
+
+        $orderedImportsRule = (new Ibexa50RuleSet())->getRules()['ordered_imports'];
+        self::assertIsArray($orderedImportsRule);
+        $this->fixer->configure($orderedImportsRule);
+    }
+
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFixDoesNotSplitImportTypesIntoSeparateGroups(
+        string $input,
+        string $expected
+    ): void {
+        $tokens = Tokens::fromCode($input);
+        $this->fixer->fix(new SplFileInfo(__FILE__), $tokens);
+
+        self::assertSame($expected, $tokens->generateCode());
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function provideFixCases(): iterable
+    {
+        yield 'function import stays in the same block as class imports' => [
+            <<<'PHP'
+                <?php
+                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+                use Symfony\Component\DependencyInjection\Reference;
+                PHP,
+            <<<'PHP'
+                <?php
+                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+                use Symfony\Component\DependencyInjection\Reference;
+                PHP,
+        ];
+
+        yield 'const import stays in the same block as class imports' => [
+            <<<'PHP'
+                <?php
+                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
+                use Symfony\Component\DependencyInjection\Reference;
+                PHP,
+            <<<'PHP'
+                <?php
+                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
+                use Symfony\Component\DependencyInjection\Reference;
+                PHP,
+        ];
+
+        yield 'mixed import types are sorted alphabetically without grouping' => [
+            <<<'PHP'
+                <?php
+                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+                use Symfony\Component\DependencyInjection\Reference;
+                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
+                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                PHP,
+            <<<'PHP'
+                <?php
+                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
+                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+                use Symfony\Component\DependencyInjection\Reference;
+                PHP,
+        ];
+    }
+}

--- a/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
@@ -34,7 +34,7 @@ final class OrderedImportsFixerTest extends TestCase
         $orderedImportsFixer = new OrderedImportsFixer();
         $orderedImportsFixer->configure($orderedImportsRule);
 
-        /** @var list<FixerInterface> $fixers */
+        /** @var array<int, FixerInterface> $fixers */
         $fixers = [
             $orderedImportsFixer,
             new BlankLineBetweenImportGroupsFixer(),

--- a/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
@@ -81,7 +81,7 @@ final class OrderedImportsFixerTest extends TestCase
                     PHP,
             ];
 
-            yield $ruleSetName . ' const import is moved to its own group after function imports' => [
+            yield $ruleSetName . ' const import is moved to its own group after class imports' => [
                 $ruleSet,
                 <<<'PHP'
                     <?php

--- a/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\CodeStyle\PhpCsFixer\Rule;
 
+use Ibexa\CodeStyle\PhpCsFixer\Sets\Ibexa46RuleSet;
 use Ibexa\CodeStyle\PhpCsFixer\Sets\Ibexa50RuleSet;
+use Ibexa\CodeStyle\PhpCsFixer\Sets\RuleSetInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\Whitespace\BlankLineBetweenImportGroupsFixer;
@@ -18,33 +20,29 @@ use SplFileInfo;
 
 final class OrderedImportsFixerTest extends TestCase
 {
-    /** @var list<FixerInterface> */
-    private array $fixers;
-
-    protected function setUp(): void
-    {
-        $orderedImportsRule = (new Ibexa50RuleSet())->getRules()['ordered_imports'];
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFixGroupsAndSortsImportsByType(
+        RuleSetInterface $ruleSet,
+        string $input,
+        string $expected
+    ): void {
+        $orderedImportsRule = $ruleSet->getRules()['ordered_imports'];
         self::assertIsArray($orderedImportsRule);
 
         $orderedImportsFixer = new OrderedImportsFixer();
         $orderedImportsFixer->configure($orderedImportsRule);
 
-        $this->fixers = [
+        /** @var list<FixerInterface> $fixers */
+        $fixers = [
             $orderedImportsFixer,
             new BlankLineBetweenImportGroupsFixer(),
         ];
-    }
 
-    /**
-     * @dataProvider provideFixCases
-     */
-    public function testFixGroupsAndSortsImportsByType(
-        string $input,
-        string $expected
-    ): void {
         $tokens = Tokens::fromCode($input);
 
-        foreach ($this->fixers as $fixer) {
+        foreach ($fixers as $fixer) {
             if (!$fixer->isCandidate($tokens)) {
                 continue;
             }
@@ -56,59 +54,69 @@ final class OrderedImportsFixerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{0: string, 1: string}>
+     * @return iterable<string, array{0: RuleSetInterface, 1: string, 2: string}>
      */
     public static function provideFixCases(): iterable
     {
-        yield 'function import is moved to its own group after class imports' => [
-            <<<'PHP'
-                <?php
-                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
-                use Symfony\Component\DependencyInjection\Reference;
-                PHP,
-            <<<'PHP'
-                <?php
-                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-                use Symfony\Component\DependencyInjection\Reference;
-
-                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
-                PHP,
+        $ruleSets = [
+            '50 ruleset' => new Ibexa50RuleSet(),
+            '46 ruleset' => new Ibexa46RuleSet(),
         ];
 
-        yield 'const import is moved to its own group after function imports' => [
-            <<<'PHP'
-                <?php
-                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
-                use Symfony\Component\DependencyInjection\Reference;
-                PHP,
-            <<<'PHP'
-                <?php
-                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-                use Symfony\Component\DependencyInjection\Reference;
+        foreach ($ruleSets as $ruleSetName => $ruleSet) {
+            yield $ruleSetName . ' function import is moved to its own group after class imports' => [
+                $ruleSet,
+                <<<'PHP'
+                    <?php
+                    use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                    use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+                    use Symfony\Component\DependencyInjection\Reference;
+                    PHP,
+                <<<'PHP'
+                    <?php
+                    use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                    use Symfony\Component\DependencyInjection\Reference;
 
-                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
-                PHP,
-        ];
+                    use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+                    PHP,
+            ];
 
-        yield 'mixed import types are sorted alphabetically within separate groups' => [
-            <<<'PHP'
-                <?php
-                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
-                use Symfony\Component\DependencyInjection\Reference;
-                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
-                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-                PHP,
-            <<<'PHP'
-                <?php
-                use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-                use Symfony\Component\DependencyInjection\Reference;
+            yield $ruleSetName . ' const import is moved to its own group after function imports' => [
+                $ruleSet,
+                <<<'PHP'
+                    <?php
+                    use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                    use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
+                    use Symfony\Component\DependencyInjection\Reference;
+                    PHP,
+                <<<'PHP'
+                    <?php
+                    use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                    use Symfony\Component\DependencyInjection\Reference;
 
-                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+                    use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
+                    PHP,
+            ];
 
-                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
-                PHP,
-        ];
+            yield $ruleSetName . ' mixed import types are sorted alphabetically within separate groups' => [
+                $ruleSet,
+                <<<'PHP'
+                    <?php
+                    use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+                    use Symfony\Component\DependencyInjection\Reference;
+                    use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
+                    use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                    PHP,
+                <<<'PHP'
+                    <?php
+                    use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+                    use Symfony\Component\DependencyInjection\Reference;
+
+                    use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+
+                    use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
+                    PHP,
+            ];
+        }
     }
 }

--- a/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/OrderedImportsFixerTest.php
@@ -9,33 +9,48 @@ declare(strict_types=1);
 namespace Ibexa\Tests\CodeStyle\PhpCsFixer\Rule;
 
 use Ibexa\CodeStyle\PhpCsFixer\Sets\Ibexa50RuleSet;
+use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBetweenImportGroupsFixer;
 use PhpCsFixer\Tokenizer\Tokens;
 use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 
 final class OrderedImportsFixerTest extends TestCase
 {
-    private OrderedImportsFixer $fixer;
+    /** @var list<FixerInterface> */
+    private array $fixers;
 
     protected function setUp(): void
     {
-        $this->fixer = new OrderedImportsFixer();
-
         $orderedImportsRule = (new Ibexa50RuleSet())->getRules()['ordered_imports'];
         self::assertIsArray($orderedImportsRule);
-        $this->fixer->configure($orderedImportsRule);
+
+        $orderedImportsFixer = new OrderedImportsFixer();
+        $orderedImportsFixer->configure($orderedImportsRule);
+
+        $this->fixers = [
+            $orderedImportsFixer,
+            new BlankLineBetweenImportGroupsFixer(),
+        ];
     }
 
     /**
      * @dataProvider provideFixCases
      */
-    public function testFixDoesNotSplitImportTypesIntoSeparateGroups(
+    public function testFixGroupsAndSortsImportsByType(
         string $input,
         string $expected
     ): void {
         $tokens = Tokens::fromCode($input);
-        $this->fixer->fix(new SplFileInfo(__FILE__), $tokens);
+
+        foreach ($this->fixers as $fixer) {
+            if (!$fixer->isCandidate($tokens)) {
+                continue;
+            }
+
+            $fixer->fix(new SplFileInfo(__FILE__), $tokens);
+        }
 
         self::assertSame($expected, $tokens->generateCode());
     }
@@ -45,7 +60,7 @@ final class OrderedImportsFixerTest extends TestCase
      */
     public static function provideFixCases(): iterable
     {
-        yield 'function import stays in the same block as class imports' => [
+        yield 'function import is moved to its own group after class imports' => [
             <<<'PHP'
                 <?php
                 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -55,12 +70,13 @@ final class OrderedImportsFixerTest extends TestCase
             <<<'PHP'
                 <?php
                 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
                 use Symfony\Component\DependencyInjection\Reference;
+
+                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
                 PHP,
         ];
 
-        yield 'const import stays in the same block as class imports' => [
+        yield 'const import is moved to its own group after function imports' => [
             <<<'PHP'
                 <?php
                 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -70,12 +86,13 @@ final class OrderedImportsFixerTest extends TestCase
             <<<'PHP'
                 <?php
                 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
                 use Symfony\Component\DependencyInjection\Reference;
+
+                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
                 PHP,
         ];
 
-        yield 'mixed import types are sorted alphabetically without grouping' => [
+        yield 'mixed import types are sorted alphabetically within separate groups' => [
             <<<'PHP'
                 <?php
                 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
@@ -86,9 +103,11 @@ final class OrderedImportsFixerTest extends TestCase
             <<<'PHP'
                 <?php
                 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
-                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
                 use Symfony\Component\DependencyInjection\Reference;
+
+                use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+
+                use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
                 PHP,
         ];
     }

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/local_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/local_rules.php
@@ -131,7 +131,10 @@ return [
     'non_printable_character' => true,
     'normalize_index_brace' => true,
     'object_operator_without_whitespace' => true,
-    'ordered_imports' => true,
+    'ordered_imports' => [
+        'imports_order' => null,
+        'sort_algorithm' => 'alpha',
+    ],
     'php_unit_construct' => true,
     'php_unit_fqcn_annotation' => true,
     'php_unit_mock_short_will_return' => false,

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/local_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/local_rules.php
@@ -132,7 +132,7 @@ return [
     'normalize_index_brace' => true,
     'object_operator_without_whitespace' => true,
     'ordered_imports' => [
-        'imports_order' => null,
+        'imports_order' => ['class', 'function', 'const'],
         'sort_algorithm' => 'alpha',
     ],
     'php_unit_construct' => true,

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/php_cs_fixer_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/php_cs_fixer_rules.php
@@ -16,7 +16,7 @@ return [
     'no_leading_import_slash' => true,
     'no_whitespace_in_blank_line' => true,
     'ordered_imports' => [
-        'imports_order' => null,
+        'imports_order' => ['class', 'function', 'const'],
         'sort_algorithm' => 'alpha',
     ],
     'return_type_declaration' => true,

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/php_cs_fixer_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/4_6_rule_set/php_cs_fixer_rules.php
@@ -15,7 +15,10 @@ return [
     'no_blank_lines_after_class_opening' => true,
     'no_leading_import_slash' => true,
     'no_whitespace_in_blank_line' => true,
-    'ordered_imports' => true,
+    'ordered_imports' => [
+        'imports_order' => null,
+        'sort_algorithm' => 'alpha',
+    ],
     'return_type_declaration' => true,
     'short_scalar_cast' => true,
     'single_import_per_statement' => true,

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/local_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/local_rules.php
@@ -132,7 +132,10 @@ return [
     'non_printable_character' => true,
     'normalize_index_brace' => true,
     'object_operator_without_whitespace' => true,
-    'ordered_imports' => true,
+    'ordered_imports' => [
+        'imports_order' => null,
+        'sort_algorithm' => 'alpha',
+    ],
     'php_unit_construct' => true,
     'php_unit_fqcn_annotation' => true,
     'php_unit_mock_short_will_return' => false,

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/local_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/local_rules.php
@@ -133,7 +133,7 @@ return [
     'normalize_index_brace' => true,
     'object_operator_without_whitespace' => true,
     'ordered_imports' => [
-        'imports_order' => null,
+        'imports_order' => ['class', 'function', 'const'],
         'sort_algorithm' => 'alpha',
     ],
     'php_unit_construct' => true,

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
@@ -24,7 +24,10 @@ return [
     'no_blank_lines_after_class_opening' => true,
     'no_leading_import_slash' => true,
     'no_whitespace_in_blank_line' => true,
-    'ordered_imports' => true,
+    'ordered_imports' => [
+        'imports_order' => null,
+        'sort_algorithm' => 'alpha',
+    ],
     'return_type_declaration' => true,
     'short_scalar_cast' => true,
     'single_import_per_statement' => true,

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
@@ -25,7 +25,7 @@ return [
     'no_leading_import_slash' => true,
     'no_whitespace_in_blank_line' => true,
     'ordered_imports' => [
-        'imports_order' => null,
+        'imports_order' => ['class', 'function', 'const'],
         'sort_algorithm' => 'alpha',
     ],
     'return_type_declaration' => true,


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR makes the ordered imports behavior explicit in the Ibexa code style preset. Instead of relying on the upstream default configuration of `ordered_imports`, the preset now defines the intended import grouping order directly, so class, function, and const imports are grouped consistently, and each group is sorted alphabetically. This avoids behavior changes caused by future php-cs-fixer default changes.

For example, input like:
```
  use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
  use Symfony\Component\DependencyInjection\Reference;
  use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
  use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
```
  is now expected to be formatted as:
```
  use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
  use Symfony\Component\DependencyInjection\Reference;

  use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;

  use const Symfony\Component\DependencyInjection\Loader\Configurator\SOME_CONST;
```
  The PR also strengthens test coverage by adding a regression test for grouped imports and running the same expectations against both Ibexa46RuleSet and Ibexa50RuleSet.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
