### PR TITLE
IBX-11773: Bumped friendsofphp/php-cs-fixer to v3.95.1 and related changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "friendsofphp/php-cs-fixer": "v3.89.1",
+        "friendsofphp/php-cs-fixer": "v3.95.1",
         "composer-runtime-api": ">=2.0"
     },
     "require-dev": {

--- a/src/lib/PhpCsFixer/InternalConfigFactory.php
+++ b/src/lib/PhpCsFixer/InternalConfigFactory.php
@@ -89,8 +89,12 @@ final class InternalConfigFactory
             $this->customRules,
         ));
 
-        if ($this->runInParallel && $config instanceof ParallelAwareConfigInterface) {
-            $config->setParallelConfig(ParallelConfigFactory::detect());
+        if ($config instanceof ParallelAwareConfigInterface) {
+            $config->setParallelConfig(
+                $this->runInParallel
+                    ? ParallelConfigFactory::detect()
+                    : ParallelConfigFactory::sequential()
+            );
         }
 
         return $config;

--- a/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
+++ b/tests/lib/PhpCsFixer/Rule/MultilineParametersFixerTest.php
@@ -41,76 +41,100 @@ final class MultilineParametersFixerTest extends TestCase
     public static function provideFixCases(): iterable
     {
         yield 'single parameter should not be modified' => [
-            '<?php
-function bar(array $package): void {
-}',
-            '<?php
-function bar(array $package): void {
-}',
+            <<<'PHP'
+                <?php
+                function bar(array $package): void {
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                function bar(array $package): void {
+                }
+                PHP,
         ];
 
         yield 'single parameter with type hints should not be modified' => [
-            '<?php
-function bar(?string $package = null): void {
-}',
-            '<?php
-function bar(?string $package = null): void {
-}',
+            <<<'PHP'
+                <?php
+                function bar(?string $package = null): void {
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                function bar(?string $package = null): void {
+                }
+                PHP,
         ];
 
         yield 'multiple parameters should be split' => [
-            '<?php
-function foo(array $package, string $expectedRuleSetClass): void {
-}',
-            '<?php
-function foo(
-    array $package,
-    string $expectedRuleSetClass
-): void {
-}',
+            <<<'PHP'
+                <?php
+                function foo(array $package, string $expectedRuleSetClass): void {
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                function foo(
+                    array $package,
+                    string $expectedRuleSetClass
+                ): void {
+                }
+                PHP,
         ];
 
         yield 'multiple parameters with type hints should be split' => [
-            '<?php
-function test(?string $foo = null, int $bar = 42): string {
-}',
-            '<?php
-function test(
-    ?string $foo = null,
-    int $bar = 42
-): string {
-}',
+            <<<'PHP'
+                <?php
+                function test(?string $foo = null, int $bar = 42): string {
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                function test(
+                    ?string $foo = null,
+                    int $bar = 42
+                ): string {
+                }
+                PHP,
         ];
 
         yield 'constructor with properties should be split' => [
-            '<?php
-class Test {
-    public function __construct(string $foo, int $bar) {
-    }
-}',
-            '<?php
-class Test {
-    public function __construct(
-        string $foo,
-        int $bar
-    ) {
-    }
-}',
+            <<<'PHP'
+                <?php
+                class Test {
+                    public function __construct(string $foo, int $bar) {
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                class Test {
+                    public function __construct(
+                        string $foo,
+                        int $bar
+                    ) {
+                    }
+                }
+                PHP,
         ];
 
         yield 'already multiline should not be modified' => [
-            '<?php
-function test(
-    string $foo,
-    int $bar
-): void {
-}',
-            '<?php
-function test(
-    string $foo,
-    int $bar
-): void {
-}',
+            <<<'PHP'
+                <?php
+                function test(
+                    string $foo,
+                    int $bar
+                ): void {
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                function test(
+                    string $foo,
+                    int $bar
+                ): void {
+                }
+                PHP,
         ];
     }
 }

--- a/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
+++ b/tests/lib/PhpCsFixer/Sets/expected_rules/5_0_rule_set/php_cs_fixer_rules.php
@@ -208,4 +208,5 @@ return [
     'fully_qualified_strict_types' => [
         'import_symbols' => true,
     ],
+    'attribute_block_no_spaces' => true,
 ];


### PR DESCRIPTION
| :ticket: Issue | IBX-11773 |
|----------------|-----------|

#### Description:
Bumped dependency to unblock update of phpunit in the newest version 13.1 (in any packages depending on this one).

The only rule which is added by default in `@PER-CS2x0` standard is https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9264. I've adjusted tests to that change.

Also, since `friendsofphp/php-cs-fixer:v3.94.0` parallel execution is enabled by default, so I adjusted our config factory to keep the current behaviour.

#### For QA:
#### Documentation: